### PR TITLE
enhance

### DIFF
--- a/src/components/vue-pdf/vue-pdf.vue
+++ b/src/components/vue-pdf/vue-pdf.vue
@@ -28,6 +28,13 @@ export default defineComponent({
       default: 1
     },
     /**
+     * Whether to display all pages, dangerous!!
+     */
+    allPages: {
+      type: Boolean,
+      default: false
+    },
+    /**
      * The scale (zoom) of the pdf. Setting this will also disable auto scaling and resizing. 
      */
     scale: {
@@ -62,6 +69,7 @@ export default defineComponent({
     const eventBus = ref(null)
 
     const pageNumber = computed(() => props.page || 1)
+    const allPages = computed(() => Boolean(props.allPages))
 
     const initPdfWorker = () => {
       loading.value = true
@@ -72,7 +80,12 @@ export default defineComponent({
         thePDF.value = pdf
         numberOfPages.value = pdf.numPages
         ctx.emit('totalPages', numberOfPages.value)
-        if (pageNumber.value <= numberOfPages.value) {
+        if (allPages.value) {
+          // ignore pageNumber, render all
+          for (let p = 1; p <= numberOfPages.value; p += 1) {
+            pdf.getPage(p).then((page: PDFPageProxy) => renderPage(page))
+          }
+        } else if (pageNumber.value <= numberOfPages.value) {
           pdf.getPage(pageNumber.value).then((page: PDFPageProxy) => renderPage(page))
         }
       })

--- a/src/components/vue-pdf/vue-pdf.vue
+++ b/src/components/vue-pdf/vue-pdf.vue
@@ -54,6 +54,10 @@ export default defineComponent({
     enableAnnotations: {
       type: Boolean,
       default: true
+    },
+    wrapperIdPrefix: {
+      type: String,
+      default: 'vue-pdf-page'
     }
   },
   setup(props: VuePdfPropsType, ctx) {
@@ -70,6 +74,7 @@ export default defineComponent({
 
     const pageNumber = computed(() => props.page || 1)
     const allPages = computed(() => Boolean(props.allPages))
+    const wrapperIdPrefix = computed(() => props.wrapperIdPrefix || 'vue-pdf-page')
 
     const initPdfWorker = () => {
       loading.value = true
@@ -101,7 +106,7 @@ export default defineComponent({
       // Create a wrapper for each page
       const pageWrapper = document.createElement('div')
       pageWrapper.classList.add('vue-pdf__wrapper')
-      pageWrapper.id = `vue-pdf-page-${props.page}`
+      pageWrapper.id = `${wrapperIdPrefix}-${props.page}`
 
       // Create a canvas element for each page to draw on
       const canvas = document.createElement('canvas')


### PR DESCRIPTION
1. add `allPages` prop to display all pages
   This prop is dangerous, but is useful if you have already known the documet page size.

2. add page wrapper id prefix
   To avoid the duplicate ids