### PR TITLE
Add prop `allPages` and `wrapperIdPrefix`, upgrade pdfjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build-storybook": "scripts/build-docs.sh"
   },
   "dependencies": {
-    "pdfjs-dist": "^2.10.377",
+    "pdfjs-dist": "^2.15.349",
     "vue": "^3.2.19"
   },
   "devDependencies": {

--- a/src/components/vue-pdf/vue-pdf-props.ts
+++ b/src/components/vue-pdf/vue-pdf-props.ts
@@ -6,4 +6,5 @@ export interface VuePdfPropsType {
   scale?: number;
   enableTextSelection?: boolean;
   enableAnnotations?: boolean;
+  wrapperIdPrefix?: string;
 }

--- a/src/components/vue-pdf/vue-pdf-props.ts
+++ b/src/components/vue-pdf/vue-pdf-props.ts
@@ -3,6 +3,7 @@ import { DocumentInitParameters, PDFDataRangeTransport } from 'pdfjs-dist/types/
 export interface VuePdfPropsType {
   src: string | URL | Uint8Array | PDFDataRangeTransport | DocumentInitParameters;
   page?: number;
+  allPages?: boolean;
   scale?: number;
   enableTextSelection?: boolean;
   enableAnnotations?: boolean;

--- a/src/components/vue-pdf/vue-pdf.vue
+++ b/src/components/vue-pdf/vue-pdf.vue
@@ -47,6 +47,13 @@ export default defineComponent({
     enableAnnotations: {
       type: Boolean,
       default: true
+    },
+    /**
+     * page wrapper id prefix
+     */
+    wrapperIdPrefix: {
+      type: String,
+      default: 'vue-pdf-page'
     }
   },
   setup(props: VuePdfPropsType, ctx) {
@@ -62,6 +69,7 @@ export default defineComponent({
     const eventBus = ref(null)
 
     const pageNumber = computed(() => props.page || 1)
+    const wrapperIdPrefix = computed(() => props.wrapperIdPrefix || 'vue-pdf-page')
 
     const initPdfWorker = () => {
       loading.value = true
@@ -88,7 +96,7 @@ export default defineComponent({
       // Create a wrapper for each page
       const pageWrapper = document.createElement('div')
       pageWrapper.classList.add('vue-pdf__wrapper')
-      pageWrapper.id = `vue-pdf-page-${props.page}`
+      pageWrapper.id = `${wrapperIdPrefix.value}-${page.pageNumber}`
 
       // Create a canvas element for each page to draw on
       const canvas = document.createElement('canvas')

--- a/src/components/vue-pdf/vue-pdf.vue
+++ b/src/components/vue-pdf/vue-pdf.vue
@@ -28,6 +28,13 @@ export default defineComponent({
       default: 1
     },
     /**
+     * Whether to display all pages, dangerous!!
+     */
+    allPages: {
+      type: Boolean,
+      default: false
+    },
+    /**
      * The scale (zoom) of the pdf. Setting this will also disable auto scaling and resizing. 
      */
     scale: {
@@ -69,6 +76,7 @@ export default defineComponent({
     const eventBus = ref(null)
 
     const pageNumber = computed(() => props.page || 1)
+    const allPages = computed(() => Boolean(props.allPages))
     const wrapperIdPrefix = computed(() => props.wrapperIdPrefix || 'vue-pdf-page')
 
     const initPdfWorker = () => {
@@ -80,7 +88,11 @@ export default defineComponent({
         thePDF.value = pdf
         numberOfPages.value = pdf.numPages
         ctx.emit('totalPages', numberOfPages.value)
-        if (pageNumber.value <= numberOfPages.value) {
+        if (allPages.value) {
+          // ignore pageNumber, display all pages
+          const pagePromiseArr = new Array(numberOfPages.value).fill(0).map((v, idx) => pdf.getPage(idx + 1))
+          Promise.all(pagePromiseArr).then(pages => pages.forEach(renderPage));
+        } else if (pageNumber.value <= numberOfPages.value) {
           pdf.getPage(pageNumber.value).then((page: PDFPageProxy) => renderPage(page))
         }
       })

--- a/src/components/vue-pdf/vue-pdf.vue
+++ b/src/components/vue-pdf/vue-pdf.vue
@@ -255,6 +255,7 @@ export default defineComponent({
             })
           }
           loading.value = false
+          ctx.emit('pageLoaded', page)
         })
       }
     }

--- a/src/components/vue-pdf/vue-pdf.vue
+++ b/src/components/vue-pdf/vue-pdf.vue
@@ -236,7 +236,7 @@ export default defineComponent({
 
               if (!linkService.value) {
                 linkService.value = new pdfjsViewer.PDFLinkService({
-                  eventBus,
+                  eventBus: eventBus.value,
                   externalLinkEnabled: true,
                   externalLinkRel: 'noopener noreferrer nofollow',
                   externalLinkTarget: 2 // Blank

--- a/src/components/vue-pdf/vue-pdf.vue
+++ b/src/components/vue-pdf/vue-pdf.vue
@@ -8,6 +8,7 @@ import { PageViewport } from 'pdfjs-dist/types/src/display/display_utils'
 import { createLoadingTask } from './loading-task'
 import 'pdfjs-dist/legacy/web/pdf_viewer.css'
 import { VuePdfPropsType } from './vue-pdf-props'
+import { IPDFLinkService } from 'pdfjs-dist/types/web/interfaces'
 
 export default defineComponent({
   name: 'vue-pdf',
@@ -74,6 +75,7 @@ export default defineComponent({
     const numberOfPages = ref<number>(0)
 
     const eventBus = ref(null)
+    const linkService = ref<IPDFLinkService | null>(null)
 
     const pageNumber = computed(() => props.page || 1)
     const allPages = computed(() => Boolean(props.allPages))
@@ -232,15 +234,23 @@ export default defineComponent({
             page.getAnnotations().then((annotationData) => {
               annotationLayer.style.cssText = `left: 0; top: 0; height: ${viewport.height}px; width: ${props.scale ? viewport.width : pdfWrapperElWidth}px;`
 
+              if (!linkService.value) {
+                linkService.value = new pdfjsViewer.PDFLinkService({
+                  eventBus,
+                  externalLinkEnabled: true,
+                  externalLinkRel: 'noopener noreferrer nofollow',
+                  externalLinkTarget: 2 // Blank
+                })
+              }
               // Render the annotation layer
               pdfjsLib.AnnotationLayer.render({
                 viewport: viewport.clone({ dontFlip: true }),
                 div: annotationLayer,
                 annotations: annotationData,
                 page: page,
-                linkService: '',
+                linkService: linkService.value as IPDFLinkService,
                 downloadManager: '',
-                renderInteractiveForms: false
+                renderForms: false
               })
             })
           }


### PR DESCRIPTION
1. add `allPages` prop for display all pages
    This prop is dangerous, but is usefull if we have already known the document page size.

2. add page wrapper id prefix
    To avoid duplicate ids.

3. upgrade pdfjs